### PR TITLE
Fix nologin typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf install -y python3.12 python3.12-pip && \
     microdnf clean all
 
 # Create a minimal non-root service user with no home directory
-RUN useradd --system --no-create-home --shell /sbin/nologinn appuser
+RUN useradd --system --no-create-home --shell /sbin/nologin appuser
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Correct shell path in Dockerfile useradd command

## Testing
- `docker build -t mail_trace_viewer:test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5c0b539c083339d2b646c40c833f5