### PR TITLE
Fix parsing of bracketed IP addresses

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -43,9 +43,9 @@ def extract_hops(raw_headers):
     received_headers = msg.get_all('Received') or []
     hops = []
     for line in received_headers:
-        match = re.search(r'from\s+(\S+)', line)
+        match = re.search(r'from\s+(\S+)', line, re.IGNORECASE)
         if match:
-            host = match.group(1)
+            host = match.group(1).strip('[]')
             if is_ip_address(host):
                 hops.append({
                     'hostname': host,

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,9 @@
+import parser
+
+
+def test_extract_hops_bracket_ip():
+    headers = "Received: from [203.0.113.1] by example.com;\n\n"
+    hops = parser.extract_hops(headers)
+    assert hops[0]['hostname'] == '203.0.113.1'
+    assert hops[0]['ip'] == '203.0.113.1'
+


### PR DESCRIPTION
## Summary
- handle bracketed IPs when extracting hops from email headers
- test hop extraction with bracketed IP address

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68962121cd2c8333a7c5057840b4dc25